### PR TITLE
fix: longitudes unwrapping in the same convention as geobox

### DIFF
--- a/altimetry/search/plotting.py
+++ b/altimetry/search/plotting.py
@@ -326,15 +326,11 @@ def plot_line(
 
 
 def _get_lons_lats(outer: list[geographic.Point], east: float):
-    lons = numpy.array([p.lon for p in outer])
+    # Add the east point of the geographical box. This will ensure numpy
+    # unwrapping will put the longitudes in the same convention as the box.
+    lons = numpy.array([east] + [p.lon for p in outer])
     lats = numpy.array([p.lat for p in outer])
-    lons = numpy.deg2rad(
-        (numpy.array([p.lon
-                      for p in outer], dtype=numpy.float64) - east) % 360.0 +
-        east)
-    lons = numpy.unwrap(lons, discont=numpy.pi)
-    lons = numpy.rad2deg(lons)
-
+    lons = numpy.unwrap(lons, period=360)[1:]
     return lons, lats
 
 


### PR DESCRIPTION
Some corner cases showed swaths on the incorrect part of the globe:

<img width="1573" height="474" alt="image" src="https://github.com/user-attachments/assets/882ddfdc-9376-4892-a41d-029ea087ada7" />

This behavior arises when the intersection result gives a line that begins just before the minimum longitude. If for example, the box longitude range is set to (-20, 20), and the returned intersection given has longitudes: such as :
[-20.000004, -20.0000004, -19.90815163 -19.51747513, ...], then the unwrapping will return [340., 340., 340.09184837, 340.48252487, ...]

We might want to add a tolerance in :func:`altimetry.search.plotting:_get_lons_lats`. This means we must switch from ``(lons - west) % 360 + west`` to a direct numpy unwrapping. This will avoid negative ``lons - west`` that are normalized and 'sent' to another longitudes convention.
